### PR TITLE
Updated asyncio module for task-like execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,13 +220,17 @@ ns/ctxswitch: 233
 
 Contributions welcome.
 
+* Multi-threading support
 * Libraries
-  * (WIP) Task library: schedulers, futures, cancellation
+  * TLS, HTTP, WebSocket
+  * Actors
   * Recursive data structure iterators
   * Parsers
+* Alternative async IO loops (e.g. libuv)
 * Debugging
     * Coro names
     * Tracing tools
+    * Dependency graphs
     * Detect incomplete coroutines
     * ASAN, TSAN, Valgrind support
 * Make it so that it's as easy as possible to switch to Zig's async when it's
@@ -240,6 +244,16 @@ Contributions welcome.
 
 ### TODO
 
+* Concurrent execution with async/await-like semantics and helpers
+  (waitAll, waitFirst, asReady, ...).
+* Cancellation and timeouts
+* Async iterators
+* Revisit storage of args/return/yield.
+  * Considering lifetimes, args and yields/injects need to be
+    available for the duration of the coroutine, while the return
+    outlasts the coroutine. Return storage should probably be on
+    the outside, but argument storage can probably safely be moved
+    into the coroutine stack without compromising useful control.
 * Revisit CoroFunc state machine:
   * If a coroutine errors, it will be in the Done state and retval will be set
     to the error. The caller in that situation will have to test whether the

--- a/README.md
+++ b/README.md
@@ -247,13 +247,7 @@ Contributions welcome.
   (waitAll, waitFirst, asReady, ...).
 * Cancellation and timeouts
 * Async iterators
-* Revisit storage of args/return/yield.
-  * Considering lifetimes, args and yields/injects need to be
-    available for the duration of the coroutine, while the return
-    outlasts the coroutine. Return storage should probably be on
-    the outside, but argument storage can probably safely be moved
-    into the coroutine stack without compromising useful control.
-* Revisit CoroFunc state machine:
+* Better coroutine error propagation
   * If a coroutine errors, it will be in the Done state and retval will be set
     to the error. The caller in that situation will have to test whether the
     coro is Done to call xreturned instead of xnext. The YieldT should probably

--- a/README.md
+++ b/README.md
@@ -2,17 +2,7 @@
 
 Async Zig as a library using stackful asymmetric coroutines.
 
-* Stackful: each coroutine has an explicitly allocated stack and
-  suspends/yields preserve the entire call stack of the coroutine. An
-  ergonomic "stackless" implementation would require language support and
-  that's what we expect to see with Zig's async functionality.
-* Asymmetric: coroutines are nested such that there is a "caller"/"callee"
-  relationship, starting with a root coroutine per thread. The caller coroutine
-  is the parent such that upon completion of the callee (the child coroutine),
-  control will transfer to the caller. Intermediate yields/suspends transfer
-  control to the last resuming coroutine.
-
-Async IO is provided by [`libxev`][libxev].
+Supports async IO via [`libxev`][libxev].
 
 ---
 
@@ -23,18 +13,15 @@ supports {Linux, Mac} `aarch64`.*
 
 ## Current status
 
-*Updated 2023/09/06*
+*Updated 2023/09/08*
 
 Alpha, WIP.
 
-Further exploring (structured) concurrency and cooperative multitasking atop
-`libxev` using coroutines.
+Currently fleshing out async io atop `libxev`. See [TODOs](#TODO) for current work.
 
 ## Coroutine API
 
 ```
-stackAlloc(allocator, size)->[]u8
-remainingStackSize()->usize
 xcurrent()->*Coro
 xcurrentStorage(T)->*T
 xresume(*coro)
@@ -43,28 +30,38 @@ Coro
   init(*func, *stack, ?*storage)
   getStorage(T)
 CoroFunc(Fn)
-  init(.{args})
-  initPtr(&fn, .{args})
-  coro(*stack)->Coro
-  xresumeStart()->YieldT
-  xresume(inject)->YieldT
-  xresumeEnd(inject)->ReturnT
+  init()
+  coro(args, stack)->Coro
+  coroPtr(func, args, stack)->Coro
+  xnextStart(coro)->YieldT
+  xnext(coro, inject)->YieldT
+  xnextEnd(coro, inject)->ReturnT
   xyield(yield)->InjectT
-StackCoro
-  init(*func, .{args}, *stack)
-  frame(*func, coro)->CoroFunc(Fn)
+  xreturned(coro)->ReturnT
+
+# Stack utilities
+stackAlloc(allocator, size)->[]u8
+remainingStackSize()->usize
 ```
 
 ## Async IO API
 
-`libcoro.xev.aio` provides coroutine-friendly wrappers to all the [high-level
-async APIs][libxev-watchers] in [`libxev`][libxev].
+[`libcoro.asyncio`][aio] provides coroutine-based async IO functionality
+building upon the evented IO system of [`libxev`][libxev]. It provides
+coroutine-friendly wrappers to all the [high-level async
+APIs][libxev-watchers] in [`libxev`][libxev].
 
-See
-[`aio_test.zig`](https://github.com/rsepassi/zigcoro/blob/main/aio_test.zig)
-for usage examples.
+See [`test_aio.zig`][test-aio] for usage examples.
 
 ```
+# Run top-level coroutines in the event loop
+run
+runCoro
+
+# Concurrently run N coroutines and wait for all to complete
+xawait
+
+# IO
 sleep
 TCP
   accept
@@ -89,17 +86,11 @@ Async
   wait
 ```
 
-Stackful asymmetric coroutines provide a clean way of wrapping up async IO
-functionality, providing a programming model akin to threads (where the lightweight
-versions are variously called Coroutines, Green Threads, or Fibers). Calls to
-IO functionality are blocking from the perspective of the coroutine, but many
-coroutines can be running on the same thread.
+The IO functions are run from within a coroutine and appear as blocking, but
+internally they suspend so that other coroutines can progress.
 
-Under the hood, what's required is async IO functionality, such that a coroutine
-can submit work to be done, suspend, and then be resumed when the work is complete.
-Libraries like [libuv][libuv] and [libxev][libxev] provide cross-platform async IO,
-and this is a new Zig project, so why not depend on another new Zig project like
-libxev?
+To run several coroutines concurrently, create the coroutines and pass them
+to `asyncio.xawait`.
 
 ## Depend
 
@@ -115,15 +106,6 @@ libxev?
 const libcoro = b.dependency("zigcoro", .{}).module("libcoro");
 my_lib.addModule("libcoro", libcoro);
 ```
-
-## Coroutine Examples
-
-*TODO: Fill back in*
-
-* resume, suspend
-* storage
-* args, return
-* yield, inject
 
 ## Performance
 
@@ -216,11 +198,28 @@ ns/ctxswitch: 233
 ...
 ```
 
+## Stackful asymmetric coroutines
+
+* Stackful: each coroutine has an explicitly allocated stack and
+  suspends/yields preserve the entire call stack of the coroutine. An
+  ergonomic "stackless" implementation would require language support and
+  that's what we expect to see with Zig's async functionality.
+* Asymmetric: coroutines are nested such that there is a "caller"/"callee"
+  relationship, starting with a root coroutine per thread. The caller coroutine
+  is the parent such that upon completion of the callee (the child coroutine),
+  control will transfer to the caller. Intermediate yields/suspends transfer
+  control to the last resuming coroutine.
+
+The wonderful 2009 paper ["Revisiting Coroutines"][coropaper] describes the
+power of stackful asymmetric coroutines in particular and their various
+applications, including nonblocking IO.
+
 ## Future work
 
 Contributions welcome.
 
 * Multi-threading support
+* Simple coro stack allocator, reusing stacks
 * Libraries
   * TLS, HTTP, WebSocket
   * Actors
@@ -263,7 +262,8 @@ Contributions welcome.
 ## Inspirations
 
 * ["Revisiting Coroutines"][coropaper] by de Moura & Ierusalimschy
-* [Lua coroutines](https://www.lua.org/pil/9.1.html)
+* [Lua coroutines][lua-coro]
+* ["Structured Concurrency"][struccon] by Eric Niebler
 * https://github.com/edubart/minicoro
 * https://github.com/kurocha/coroutine
 * https://github.com/kprotty/zefi
@@ -274,3 +274,7 @@ Contributions welcome.
 [libxev]: https://github.com/mitchellh/libxev
 [libxev-watchers]: https://github.com/mitchellh/libxev/tree/main/src/watcher
 [libuv]: https://libuv.org
+[struccon]: https://ericniebler.com/2020/11/08/structured-concurrency
+[aio]: https://github.com/rsepassi/zigcoro/blob/main/src/asyncio.zig
+[test-aio]: https://github.com/rsepassi/zigcoro/blob/main/src/test_aio.zig
+[lua-coro]: https://www.lua.org/pil/9.1.html

--- a/benchmark.zig
+++ b/benchmark.zig
@@ -28,9 +28,9 @@ fn contextSwitchBm() !void {
         {
             var test_coro = try libcoro.Coro.init(testFn, stack, null);
             for (0..num_bounces) |_| {
-                libcoro.xresume(&test_coro);
+                libcoro.xresume(test_coro);
             }
-            libcoro.xresume(&test_coro);
+            libcoro.xresume(test_coro);
         }
 
         num_bounces = 20_000_000;
@@ -39,14 +39,14 @@ fn contextSwitchBm() !void {
 
             const start = std.time.nanoTimestamp();
             for (0..num_bounces) |_| {
-                libcoro.xresume(&test_coro);
+                libcoro.xresume(test_coro);
             }
             const end = std.time.nanoTimestamp();
             const duration = end - start;
             const ns_per_bounce = @divFloor(duration, num_bounces * 2);
             std.debug.print("ns/ctxswitch: {d}\n", .{ns_per_bounce});
 
-            libcoro.xresume(&test_coro);
+            libcoro.xresume(test_coro);
         }
     }
 }
@@ -113,7 +113,7 @@ fn ncorosBm(num_coros: usize) !void {
     std.debug.print("Running {d} coroutines for {d} rounds\n", .{ num_coros, rounds });
 
     // number of coroutines benchmark
-    var coros = try allocator.alloc(libcoro.Coro, num_coros);
+    var coros = try allocator.alloc(*libcoro.Coro, num_coros);
     defer allocator.free(coros);
 
     var buf = try allocator.alloc(u8, num_coros * 1024 * 4);
@@ -130,7 +130,7 @@ fn ncorosBm(num_coros: usize) !void {
 
     var start = std.time.nanoTimestamp();
     for (0..rounds) |i| {
-        for (coros) |*coro| {
+        for (coros) |coro| {
             libcoro.xresume(coro);
         }
         if ((i + 1) % batching == 0) {

--- a/build.zig
+++ b/build.zig
@@ -8,7 +8,7 @@ pub fn build(b: *std.Build) !void {
 
     // Module
     const coro = b.addModule("libcoro", .{
-        .source_file = .{ .path = "src/coro.zig" },
+        .source_file = .{ .path = "src/main.zig" },
         .dependencies = &[_]std.Build.ModuleDependency{
             .{ .name = "xev", .module = xev },
         },

--- a/src/aio_xev.zig
+++ b/src/aio_xev.zig
@@ -2,174 +2,190 @@ const std = @import("std");
 const xev = @import("xev");
 const libcoro = @import("coro.zig");
 
-// Todos
-// * Groups of coroutines: waitAll, asCompleted
-// * Timeouts, cancellations
-
-fn XCallback(comptime ResultT: type) type {
-    return struct {
-        coro: *libcoro.Coro,
-        result: ResultT = undefined,
-
-        fn init() @This() {
-            return .{ .coro = libcoro.xcurrent() };
-        }
-
-        fn callback(
-            userdata: ?*@This(),
-            l: *xev.Loop,
-            c: *xev.Completion,
-            result: ResultT,
-        ) xev.CallbackAction {
-            _ = l;
-            _ = c;
-            const data = userdata.?;
-            data.result = result;
-            libcoro.xresume(data.coro);
-            return .disarm;
-        }
-    };
+// Run a coroutine to completion.
+// Must be called from "root", outside of any created coroutine.
+// TODO: when xreturned returns an error, program crashes. I
+// suspect something gone wrong in error set inference. The
+// intention is to join the errors from the "try"s with the
+// error set of xreturned.
+pub fn run(
+    loop: *xev.Loop,
+    func: anytype,
+    args: anytype,
+    stack: libcoro.StackT,
+) !RunT(func, .{}) {
+    const CoroFn = libcoro.CoroFunc(func, .{});
+    var frame = CoroFn.init();
+    var co = try frame.coro(args, stack);
+    try runCoro(loop, co);
+    return CoroFn.xreturned(co);
 }
 
-pub const Async = struct {
-    const Self = @This();
+// Run a coroutine to completion.
+// Must be called from "root", outside of any created coroutine.
+pub fn runCoro(loop: *xev.Loop, co: *libcoro.Coro) !void {
+    std.debug.assert(co.status == .Start);
+    libcoro.xresume(co);
+    while (co.status != .Done) {
+        try loop.tick(1);
+    }
+}
 
-    loop: *xev.Loop,
-    xasync: xev.Async,
+// Run the coroutines concurrently and return when all are done.
+// coros: tuple or slice of *libcoro.Coro
+pub fn xawait(coros: anytype) void {
+    const is_tuple = @typeInfo(@TypeOf(coros)) == .Struct;
 
-    pub fn init(loop: *xev.Loop, xasync: xev.Async) Self {
-        return .{ .loop = loop, .xasync = xasync };
+    var num_suspends: usize = 0;
+
+    // Start each coro. This coro will be the parent as it is the initial
+    // resumer.
+    if (is_tuple) {
+        inline for (coros) |co| {
+            std.debug.assert(co.status == .Start or co.status == .Done);
+            if (co.status != .Done) {
+                num_suspends += 1;
+                libcoro.xresume(co);
+            }
+        }
+    } else {
+        for (coros) |co| {
+            std.debug.assert(co.status == .Start or co.status == .Done);
+            if (co.status != .Done) {
+                num_suspends += 1;
+                libcoro.xresume(co);
+            }
+        }
     }
 
-    const WaitResult = xev.Async.WaitError!void;
-    pub fn wait(self: Self) WaitResult {
-        const Data = XCallback(WaitResult);
-
-        var c: xev.Completion = .{};
-        var data = Data.init();
-        self.xasync.wait(self.loop, &c, Data, &data, &Data.callback);
-
+    // As each coro completes, it will return control here.
+    for (0..num_suspends) |_| {
         libcoro.xsuspend();
-
-        return data.result;
     }
-};
 
-pub const UDP = struct {
+    if (is_tuple) {
+        inline for (coros) |co| {
+            std.debug.assert(co.status == .Done);
+        }
+    } else {
+        for (coros) |co| {
+            std.debug.assert(co.status == .Done);
+        }
+    }
+}
+
+const SleepResult = xev.Timer.RunError!void;
+pub fn sleep(loop: *xev.Loop, ms: u64) SleepResult {
+    const Data = XCallback(SleepResult);
+
+    var data = Data.init();
+    const w = try xev.Timer.init();
+    defer w.deinit();
+    var c: xev.Completion = .{};
+    w.run(loop, &c, ms, Data, &data, &Data.callback);
+
+    libcoro.xsuspend();
+
+    return data.result;
+}
+
+pub const TCP = struct {
     const Self = @This();
 
     loop: *xev.Loop,
-    udp: xev.UDP,
+    tcp: xev.TCP,
 
-    pub usingnamespace Stream(Self, xev.UDP, .{
+    pub usingnamespace Stream(Self, xev.TCP, .{
         .close = true,
-        .read = .none,
-        .write = .none,
+        .read = .recv,
+        .write = .send,
     });
 
-    pub fn init(loop: *xev.Loop, udp: xev.UDP) Self {
-        return .{ .loop = loop, .udp = udp };
+    pub fn init(loop: *xev.Loop, tcp: xev.TCP) Self {
+        return .{ .loop = loop, .tcp = tcp };
     }
 
-    pub fn stream(self: Self) xev.UDP {
-        return self.udp;
+    fn stream(self: Self) xev.TCP {
+        return self.tcp;
     }
 
-    const ReadResult = xev.ReadError!usize;
-    pub fn read(self: Self, buf: xev.ReadBuffer) ReadResult {
-        const ResultT = ReadResult;
-        const Data = struct {
-            result: ResultT = undefined,
-            coro: *libcoro.Coro = undefined,
+    pub fn accept(self: Self) xev.TCP.AcceptError!Self {
+        const AcceptResult = xev.TCP.AcceptError!xev.TCP;
+        const Data = XCallback(AcceptResult);
 
-            fn callback(
-                userdata: ?*@This(),
-                l: *xev.Loop,
-                c: *xev.Completion,
-                s: *xev.UDP.State,
-                addr: std.net.Address,
-                udp: xev.UDP,
-                b: xev.ReadBuffer,
-                result: ResultT,
-            ) xev.CallbackAction {
-                _ = l;
-                _ = c;
-                _ = s;
-                _ = addr;
-                _ = udp;
-                _ = b;
-                const data = userdata.?;
-                data.result = result;
-                libcoro.xresume(data.coro);
-                return .disarm;
-            }
-        };
-
-        var s: xev.UDP.State = undefined;
-        var c: xev.Completion = .{};
-        var data: Data = .{ .coro = libcoro.xcurrent() };
-        self.udp.read(self.loop, &c, &s, buf, Data, &data, &Data.callback);
-
-        libcoro.xsuspend();
-
-        return data.result;
-    }
-
-    const WriteResult = xev.WriteError!usize;
-    pub fn write(self: Self, addr: std.net.Address, buf: xev.WriteBuffer) WriteResult {
-        const ResultT = WriteResult;
-        const Data = struct {
-            result: ResultT = undefined,
-            coro: *libcoro.Coro = undefined,
-
-            fn callback(
-                userdata: ?*@This(),
-                l: *xev.Loop,
-                c: *xev.Completion,
-                s: *xev.UDP.State,
-                udp: xev.UDP,
-                b: xev.WriteBuffer,
-                result: ResultT,
-            ) xev.CallbackAction {
-                _ = l;
-                _ = c;
-                _ = s;
-                _ = udp;
-                _ = b;
-                const data = userdata.?;
-                data.result = result;
-                libcoro.xresume(data.coro);
-                return .disarm;
-            }
-        };
-
-        var s: xev.UDP.State = undefined;
-        var c: xev.Completion = .{};
-        var data: Data = .{ .coro = libcoro.xcurrent() };
-        self.udp.write(self.loop, &c, &s, addr, buf, Data, &data, &Data.callback);
-
-        libcoro.xsuspend();
-
-        return data.result;
-    }
-};
-
-pub const Process = struct {
-    const Self = @This();
-
-    loop: *xev.Loop,
-    p: xev.Process,
-
-    pub fn init(loop: *xev.Loop, p: xev.Process) Self {
-        return .{ .loop = loop, .p = p };
-    }
-
-    const WaitResult = xev.Process.WaitError!u32;
-    pub fn wait(self: Self) WaitResult {
-        const Data = XCallback(WaitResult);
-        var c: xev.Completion = .{};
         var data = Data.init();
-        self.p.wait(self.loop, &c, Data, &data, &Data.callback);
+        var c: xev.Completion = .{};
+        self.tcp.accept(self.loop, &c, Data, &data, &Data.callback);
+
+        libcoro.xsuspend();
+
+        if (data.result) |result| {
+            return .{ .loop = self.loop, .tcp = result };
+        } else |err| return err;
+    }
+
+    const ConnectResult = xev.TCP.ConnectError!void;
+    pub fn connect(self: Self, addr: std.net.Address) ConnectResult {
+        const ResultT = ConnectResult;
+        const Data = struct {
+            result: ResultT = undefined,
+            coro: *libcoro.Coro = undefined,
+
+            fn callback(
+                userdata: ?*@This(),
+                l: *xev.Loop,
+                c: *xev.Completion,
+                s: xev.TCP,
+                result: ResultT,
+            ) xev.CallbackAction {
+                _ = l;
+                _ = c;
+                _ = s;
+                const data = userdata.?;
+                data.result = result;
+                libcoro.xresume(data.coro);
+                return .disarm;
+            }
+        };
+
+        var data: Data = .{ .coro = libcoro.xcurrent() };
+
+        var c: xev.Completion = .{};
+        self.tcp.connect(self.loop, &c, addr, Data, &data, &Data.callback);
+
+        libcoro.xsuspend();
+
+        return data.result;
+    }
+
+    const ShutdownResult = xev.TCP.ShutdownError!void;
+    pub fn shutdown(self: Self) ShutdownResult {
+        const ResultT = ShutdownResult;
+        const Data = struct {
+            result: ResultT = undefined,
+            coro: *libcoro.Coro = undefined,
+
+            fn callback(
+                userdata: ?*@This(),
+                l: *xev.Loop,
+                c: *xev.Completion,
+                s: xev.TCP,
+                result: ResultT,
+            ) xev.CallbackAction {
+                _ = l;
+                _ = c;
+                _ = s;
+                const data = userdata.?;
+                data.result = result;
+                libcoro.xresume(data.coro);
+                return .disarm;
+            }
+        };
+
+        var data: Data = .{ .coro = libcoro.xcurrent() };
+
+        var c: xev.Completion = .{};
+        self.tcp.shutdown(self.loop, &c, Data, &data, &Data.callback);
 
         libcoro.xsuspend();
 
@@ -400,103 +416,22 @@ pub const File = struct {
     }
 };
 
-pub const TCP = struct {
+pub const Process = struct {
     const Self = @This();
 
     loop: *xev.Loop,
-    tcp: xev.TCP,
+    p: xev.Process,
 
-    pub usingnamespace Stream(Self, xev.TCP, .{
-        .close = true,
-        .read = .recv,
-        .write = .send,
-    });
-
-    pub fn init(loop: *xev.Loop, tcp: xev.TCP) Self {
-        return .{ .loop = loop, .tcp = tcp };
+    pub fn init(loop: *xev.Loop, p: xev.Process) Self {
+        return .{ .loop = loop, .p = p };
     }
 
-    fn stream(self: Self) xev.TCP {
-        return self.tcp;
-    }
-
-    pub fn accept(self: Self) xev.TCP.AcceptError!Self {
-        const AcceptResult = xev.TCP.AcceptError!xev.TCP;
-        const Data = XCallback(AcceptResult);
-
+    const WaitResult = xev.Process.WaitError!u32;
+    pub fn wait(self: Self) WaitResult {
+        const Data = XCallback(WaitResult);
+        var c: xev.Completion = .{};
         var data = Data.init();
-        var c: xev.Completion = .{};
-        self.tcp.accept(self.loop, &c, Data, &data, &Data.callback);
-
-        libcoro.xsuspend();
-
-        if (data.result) |result| {
-            return .{ .loop = self.loop, .tcp = result };
-        } else |err| return err;
-    }
-
-    const ConnectResult = xev.TCP.ConnectError!void;
-    pub fn connect(self: Self, addr: std.net.Address) ConnectResult {
-        const ResultT = ConnectResult;
-        const Data = struct {
-            result: ResultT = undefined,
-            coro: *libcoro.Coro = undefined,
-
-            fn callback(
-                userdata: ?*@This(),
-                l: *xev.Loop,
-                c: *xev.Completion,
-                s: xev.TCP,
-                result: ResultT,
-            ) xev.CallbackAction {
-                _ = l;
-                _ = c;
-                _ = s;
-                const data = userdata.?;
-                data.result = result;
-                libcoro.xresume(data.coro);
-                return .disarm;
-            }
-        };
-
-        var data: Data = .{ .coro = libcoro.xcurrent() };
-
-        var c: xev.Completion = .{};
-        self.tcp.connect(self.loop, &c, addr, Data, &data, &Data.callback);
-
-        libcoro.xsuspend();
-
-        return data.result;
-    }
-
-    const ShutdownResult = xev.TCP.ShutdownError!void;
-    pub fn shutdown(self: Self) ShutdownResult {
-        const ResultT = ShutdownResult;
-        const Data = struct {
-            result: ResultT = undefined,
-            coro: *libcoro.Coro = undefined,
-
-            fn callback(
-                userdata: ?*@This(),
-                l: *xev.Loop,
-                c: *xev.Completion,
-                s: xev.TCP,
-                result: ResultT,
-            ) xev.CallbackAction {
-                _ = l;
-                _ = c;
-                _ = s;
-                const data = userdata.?;
-                data.result = result;
-                libcoro.xresume(data.coro);
-                return .disarm;
-            }
-        };
-
-        var data: Data = .{ .coro = libcoro.xcurrent() };
-
-        var c: xev.Completion = .{};
-        self.tcp.shutdown(self.loop, &c, Data, &data, &Data.callback);
+        self.p.wait(self.loop, &c, Data, &data, &Data.callback);
 
         libcoro.xsuspend();
 
@@ -504,17 +439,156 @@ pub const TCP = struct {
     }
 };
 
-const SleepResult = xev.Timer.RunError!void;
-pub fn sleep(loop: *xev.Loop, ms: u64) SleepResult {
-    const Data = XCallback(SleepResult);
+pub const Async = struct {
+    const Self = @This();
 
-    var data = Data.init();
-    const w = try xev.Timer.init();
-    defer w.deinit();
-    var c: xev.Completion = .{};
-    w.run(loop, &c, ms, Data, &data, &Data.callback);
+    loop: *xev.Loop,
+    xasync: xev.Async,
 
-    libcoro.xsuspend();
+    pub fn init(loop: *xev.Loop, xasync: xev.Async) Self {
+        return .{ .loop = loop, .xasync = xasync };
+    }
 
-    return data.result;
+    const WaitResult = xev.Async.WaitError!void;
+    pub fn wait(self: Self) WaitResult {
+        const Data = XCallback(WaitResult);
+
+        var c: xev.Completion = .{};
+        var data = Data.init();
+        self.xasync.wait(self.loop, &c, Data, &data, &Data.callback);
+
+        libcoro.xsuspend();
+
+        return data.result;
+    }
+};
+
+pub const UDP = struct {
+    const Self = @This();
+
+    loop: *xev.Loop,
+    udp: xev.UDP,
+
+    pub usingnamespace Stream(Self, xev.UDP, .{
+        .close = true,
+        .read = .none,
+        .write = .none,
+    });
+
+    pub fn init(loop: *xev.Loop, udp: xev.UDP) Self {
+        return .{ .loop = loop, .udp = udp };
+    }
+
+    pub fn stream(self: Self) xev.UDP {
+        return self.udp;
+    }
+
+    const ReadResult = xev.ReadError!usize;
+    pub fn read(self: Self, buf: xev.ReadBuffer) ReadResult {
+        const ResultT = ReadResult;
+        const Data = struct {
+            result: ResultT = undefined,
+            coro: *libcoro.Coro = undefined,
+
+            fn callback(
+                userdata: ?*@This(),
+                l: *xev.Loop,
+                c: *xev.Completion,
+                s: *xev.UDP.State,
+                addr: std.net.Address,
+                udp: xev.UDP,
+                b: xev.ReadBuffer,
+                result: ResultT,
+            ) xev.CallbackAction {
+                _ = l;
+                _ = c;
+                _ = s;
+                _ = addr;
+                _ = udp;
+                _ = b;
+                const data = userdata.?;
+                data.result = result;
+                libcoro.xresume(data.coro);
+                return .disarm;
+            }
+        };
+
+        var s: xev.UDP.State = undefined;
+        var c: xev.Completion = .{};
+        var data: Data = .{ .coro = libcoro.xcurrent() };
+        self.udp.read(self.loop, &c, &s, buf, Data, &data, &Data.callback);
+
+        libcoro.xsuspend();
+
+        return data.result;
+    }
+
+    const WriteResult = xev.WriteError!usize;
+    pub fn write(self: Self, addr: std.net.Address, buf: xev.WriteBuffer) WriteResult {
+        const ResultT = WriteResult;
+        const Data = struct {
+            result: ResultT = undefined,
+            coro: *libcoro.Coro = undefined,
+
+            fn callback(
+                userdata: ?*@This(),
+                l: *xev.Loop,
+                c: *xev.Completion,
+                s: *xev.UDP.State,
+                udp: xev.UDP,
+                b: xev.WriteBuffer,
+                result: ResultT,
+            ) xev.CallbackAction {
+                _ = l;
+                _ = c;
+                _ = s;
+                _ = udp;
+                _ = b;
+                const data = userdata.?;
+                data.result = result;
+                libcoro.xresume(data.coro);
+                return .disarm;
+            }
+        };
+
+        var s: xev.UDP.State = undefined;
+        var c: xev.Completion = .{};
+        var data: Data = .{ .coro = libcoro.xcurrent() };
+        self.udp.write(self.loop, &c, &s, addr, buf, Data, &data, &Data.callback);
+
+        libcoro.xsuspend();
+
+        return data.result;
+    }
+};
+
+fn RunT(comptime Func: anytype, comptime opts: libcoro.FrameOptions) type {
+    const T = libcoro.CoroSignature.init(Func, opts).getReturnT();
+    return switch (@typeInfo(T)) {
+        .ErrorUnion => |E| E.payload,
+        else => T,
+    };
+}
+
+fn XCallback(comptime ResultT: type) type {
+    return struct {
+        coro: *libcoro.Coro,
+        result: ResultT = undefined,
+
+        fn init() @This() {
+            return .{ .coro = libcoro.xcurrent() };
+        }
+
+        fn callback(
+            userdata: ?*@This(),
+            _: *xev.Loop,
+            _: *xev.Completion,
+            result: ResultT,
+        ) xev.CallbackAction {
+            const data = userdata.?;
+            data.result = result;
+            libcoro.xresume(data.coro);
+            return .disarm;
+        }
+    };
 }

--- a/src/aio_xev.zig
+++ b/src/aio_xev.zig
@@ -27,7 +27,7 @@ pub fn runCoro(loop: *xev.Loop, co: *libcoro.Coro) !void {
     std.debug.assert(co.status == .Start);
     libcoro.xresume(co);
     while (co.status != .Done) {
-        try loop.tick(1);
+        try loop.run(.once);
     }
 }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,0 +1,2 @@
+pub usingnamespace @import("coro.zig");
+pub const asyncio = @import("aio_xev.zig");

--- a/src/test_aio.zig
+++ b/src/test_aio.zig
@@ -1,37 +1,34 @@
-// TODO: update to the new API and reenable tests
-// The underlying functionality works (as demonstrated by the sleep tests) but
-// I'm leaving the other tests alone until the API settles, which should happen
-// once I've settled on what Tasks/Futures look like.
 const std = @import("std");
 const libcoro = @import("libcoro");
 const xev = @import("xev");
-const aio = libcoro.xev.aio;
+const aio = libcoro.asyncio;
 
-var env: struct { loop: *xev.Loop } = undefined;
+threadlocal var env: struct { allocator: std.mem.Allocator, loop: *xev.Loop } = undefined;
 
 const AioTest = struct {
     allocator: std.mem.Allocator,
-    loop: *xev.Loop,
     tp: *xev.ThreadPool,
+    loop: *xev.Loop,
 
     fn init() !@This() {
         const allocator = std.testing.allocator;
 
         // Allocate on heap for pointer stability
-        var loop = try allocator.create(xev.Loop);
         var tp = try allocator.create(xev.ThreadPool);
+        var loop = try allocator.create(xev.Loop);
         tp.* = xev.ThreadPool.init(.{});
         loop.* = try xev.Loop.init(.{ .thread_pool = tp });
 
         // Thread-local env
         env = .{
+            .allocator = allocator,
             .loop = loop,
         };
 
         return .{
             .allocator = allocator,
-            .loop = loop,
             .tp = tp,
+            .loop = loop,
         };
     }
 
@@ -42,28 +39,77 @@ const AioTest = struct {
         self.allocator.destroy(self.tp);
         self.allocator.destroy(self.loop);
     }
+
+    fn run(self: @This(), func: anytype) !void {
+        const stack = try libcoro.stackAlloc(self.allocator, 1024 * 8);
+        defer self.allocator.free(stack);
+        try aio.run(self.loop, func, .{}, stack);
+    }
 };
 
-fn sleepTest() !void {
-    const before = std.time.milliTimestamp();
-    try aio.sleep(env.loop, 1000);
-    const after = std.time.milliTimestamp();
-    try std.testing.expect(@fabs(@as(f64, @floatFromInt(after - before - 1000))) < 5);
-    try std.testing.expect(libcoro.remainingStackSize() > 1024 * 30);
+fn sleep(ms: u64) !i64 {
+    try aio.sleep(env.loop, ms);
+    try std.testing.expect(libcoro.remainingStackSize() > 1024 * 2);
+    return std.time.milliTimestamp();
 }
-const SleepFn = libcoro.CoroFunc(sleepTest, .{});
+const SleepFn = libcoro.CoroFunc(sleep, .{});
 
-test "aio sleep" {
+test "aio sleep run" {
     const t = try AioTest.init();
     defer t.deinit();
 
-    var fn1 = SleepFn.init(.{});
-    const stack1 = try libcoro.stackAlloc(t.allocator, 1024 * 32);
-    defer t.allocator.free(stack1);
-    var co1 = try fn1.coro(stack1);
-    libcoro.xresume(&co1);
+    const stack = try libcoro.stackAlloc(
+        t.allocator,
+        null,
+    );
+    defer t.allocator.free(stack);
+    const before = std.time.milliTimestamp();
+    const after = try aio.run(t.loop, sleep, .{500}, stack);
 
-    try t.loop.run(.until_done);
+    try std.testing.expect(after > (before + 497));
+    try std.testing.expect(after < (before + 503));
+}
+
+fn sleepTask() !void {
+    const stack = try libcoro.stackAlloc(
+        env.allocator,
+        null,
+    );
+    defer env.allocator.free(stack);
+    var frame = SleepFn.init();
+    var coro = try frame.coro(.{250}, stack);
+
+    const stack2 = try libcoro.stackAlloc(
+        env.allocator,
+        null,
+    );
+    defer env.allocator.free(stack2);
+    var frame2 = SleepFn.init();
+    var coro2 = try frame2.coro(.{500}, stack2);
+
+    aio.xawait(.{ coro, coro2 });
+
+    const after = try SleepFn.xreturned(coro);
+    const after2 = try SleepFn.xreturned(coro2);
+    try std.testing.expect(after2 > (after + 247));
+    try std.testing.expect(after2 < (after + 253));
+}
+
+test "aio concurrent sleep" {
+    const t = try AioTest.init();
+    defer t.deinit();
+
+    const stack = try libcoro.stackAlloc(
+        t.allocator,
+        1024 * 8,
+    );
+    defer t.allocator.free(stack);
+    const before = std.time.milliTimestamp();
+    try aio.run(t.loop, sleepTask, .{}, stack);
+    const after = std.time.milliTimestamp();
+
+    try std.testing.expect(after > (before + 497));
+    try std.testing.expect(after < (before + 503));
 }
 
 const TickState = struct {
@@ -72,7 +118,7 @@ const TickState = struct {
 };
 
 fn tickLoop(tick: usize, state: *TickState) !void {
-    const amfast = tick == 100;
+    const amfast = tick == 50;
     for (0..10) |i| {
         try aio.sleep(env.loop, tick);
         if (amfast) {
@@ -87,228 +133,234 @@ fn tickLoop(tick: usize, state: *TickState) !void {
 }
 const TickLoopFn = libcoro.CoroFunc(tickLoop, .{});
 
-test "aio timers" {
-    const t = try AioTest.init();
-    defer t.deinit();
-
+fn aioTimersMain() !void {
     const stack_size: usize = 1024 * 16;
 
     var tick_state = TickState{};
 
     // 2 parallel timer loops, one fast, one slow
-    var fn1 = TickLoopFn.init(.{ 100, &tick_state });
-    const stack1 = try libcoro.stackAlloc(t.allocator, stack_size);
-    defer t.allocator.free(stack1);
-    var co1 = try fn1.coro(stack1);
-    libcoro.xresume(&co1);
+    var fn1 = TickLoopFn.init();
+    const stack1 = try libcoro.stackAlloc(env.allocator, stack_size);
+    defer env.allocator.free(stack1);
+    var co1 = try fn1.coro(.{ 50, &tick_state }, stack1);
 
-    var fn2 = TickLoopFn.init(.{ 200, &tick_state });
-    const stack2 = try libcoro.stackAlloc(t.allocator, stack_size);
-    defer t.allocator.free(stack2);
-    var co2 = try fn2.coro(stack2);
-    libcoro.xresume(&co2);
+    var fn2 = TickLoopFn.init();
+    const stack2 = try libcoro.stackAlloc(env.allocator, stack_size);
+    defer env.allocator.free(stack2);
+    var co2 = try fn2.coro(.{ 100, &tick_state }, stack2);
 
-    try t.loop.run(.until_done);
+    aio.xawait(.{ co1, co2 });
 
     try std.testing.expectEqual(co1.status, .Done);
     try std.testing.expectEqual(co2.status, .Done);
-    try std.testing.expect(!std.meta.isError(TickLoopFn.xreturned(&co1)));
-    try std.testing.expect(!std.meta.isError(TickLoopFn.xreturned(&co2)));
+    try std.testing.expect(!std.meta.isError(TickLoopFn.xreturned(co1)));
+    try std.testing.expect(!std.meta.isError(TickLoopFn.xreturned(co2)));
 }
 
-// test "aio tcp" {
-//     const t = try AioTest.init();
-//     defer t.deinit();
-//
-//     const stack_size = 1024 * 32;
-//
-//     var info: ServerInfo = .{};
-//     const sco = try libcoro.xcoroAlloc(tcpServer, .{&info}, t.allocator, stack_size, .{});
-//     defer sco.deinit();
-//     try libcoro.xresume(sco);
-//
-//     const cco = try libcoro.xcoroAlloc(tcpClient, .{&info}, t.allocator, stack_size, .{});
-//     defer cco.deinit();
-//     try libcoro.xresume(cco);
-//
-//     try t.loop.run(.until_done);
-// }
-//
-// test "aio file" {
-//     const t = try AioTest.init();
-//     defer t.deinit();
-//     const stack_size = 1024 * 32;
-//     const co = try libcoro.xcoroAlloc(fileRW, .{}, t.allocator, stack_size, .{});
-//     defer co.deinit();
-//     try libcoro.xresume(co);
-//     try t.loop.run(.until_done);
-// }
-//
-// test "aio udp" {
-//     const t = try AioTest.init();
-//     defer t.deinit();
-//
-//     const stack_size = 1024 * 32;
-//     var udp_info: ServerInfo = .{};
-//
-//     const sco = try libcoro.xcoroAlloc(udpServer, .{&udp_info}, t.allocator, stack_size, .{});
-//     defer sco.deinit();
-//     try libcoro.xresume(sco);
-//
-//     const cco = try libcoro.xcoroAlloc(udpClient, .{&udp_info}, t.allocator, stack_size, .{});
-//     defer cco.deinit();
-//     try libcoro.xresume(cco);
-//
-//     try t.loop.run(.until_done);
-// }
-//
-// test "aio process" {
-//     const t = try AioTest.init();
-//     defer t.deinit();
-//
-//     const stack_size = 1024 * 32;
-//
-//     const co = try libcoro.xcoroAlloc(processTest, .{}, t.allocator, stack_size, .{});
-//     defer co.deinit();
-//     try libcoro.xresume(co);
-//
-//     try t.loop.run(.until_done);
-// }
-//
-// test "aio async" {
-//     const t = try AioTest.init();
-//     defer t.deinit();
-//
-//     const stack_size = 1024 * 32;
-//     var nstate = NotifierState{ .x = try xev.Async.init() };
-//
-//     const co = try libcoro.xcoroAlloc(asyncTest, .{&nstate}, t.allocator, stack_size, .{});
-//     defer co.deinit();
-//     try libcoro.xresume(co);
-//
-//     const nco = try libcoro.xcoroAlloc(asyncNotifier, .{&nstate}, t.allocator, stack_size, .{});
-//     defer nco.deinit();
-//     try libcoro.xresume(nco);
-//
-//     try t.loop.run(.until_done);
-// }
-//
-// const ServerInfo = struct {
-//     addr: std.net.Address = undefined,
-// };
-//
-// fn tcpServer(info: *ServerInfo) !void {
-//     var address = try std.net.Address.parseIp4("127.0.0.1", 0);
-//     const xserver = try xev.TCP.init(address);
-//
-//     try xserver.bind(address);
-//     try xserver.listen(1);
-//
-//     var sock_len = address.getOsSockLen();
-//     try std.os.getsockname(xserver.fd, &address.any, &sock_len);
-//     info.addr = address;
-//
-//     const server = aio.TCP.init(env.loop, xserver);
-//     const conn = try server.accept();
-//     defer conn.close() catch unreachable;
-//     try server.close();
-//
-//     var recv_buf: [128]u8 = undefined;
-//     const recv_len = try conn.read(.{ .slice = &recv_buf });
-//     const send_buf = [_]u8{ 1, 1, 2, 3, 5, 8, 13 };
-//     try std.testing.expect(std.mem.eql(u8, &send_buf, recv_buf[0..recv_len]));
-// }
-//
-// fn tcpClient(info: *ServerInfo) !void {
-//     const address = info.addr;
-//     const xclient = try xev.TCP.init(address);
-//     const client = aio.TCP.init(env.loop, xclient);
-//     defer client.close() catch unreachable;
-//     _ = try client.connect(address);
-//     var send_buf = [_]u8{ 1, 1, 2, 3, 5, 8, 13 };
-//     const send_len = try client.write(.{ .slice = &send_buf });
-//     try std.testing.expectEqual(send_len, 7);
-// }
-//
-// fn fileRW() !void {
-//     const path = "test_watcher_file";
-//     const f = try std.fs.cwd().createFile(path, .{
-//         .read = true,
-//         .truncate = true,
-//     });
-//     defer f.close();
-//     defer std.fs.cwd().deleteFile(path) catch {};
-//     const xfile = try xev.File.init(f);
-//     const file = aio.File.init(env.loop, xfile);
-//     var write_buf = [_]u8{ 1, 1, 2, 3, 5, 8, 13 };
-//     const write_len = try file.write(.{ .slice = &write_buf });
-//     try std.testing.expectEqual(write_len, write_buf.len);
-//     try f.sync();
-//     const f2 = try std.fs.cwd().openFile(path, .{});
-//     defer f2.close();
-//     const xfile2 = try xev.File.init(f2);
-//     const file2 = aio.File.init(env.loop, xfile2);
-//     var read_buf: [128]u8 = undefined;
-//     const read_len = try file2.read(.{ .slice = &read_buf });
-//     try std.testing.expectEqual(write_len, read_len);
-//     try std.testing.expect(std.mem.eql(u8, &write_buf, read_buf[0..read_len]));
-// }
-//
-// fn processTest() !void {
-//     const alloc = std.heap.c_allocator;
-//     var child = std.ChildProcess.init(&.{ "sh", "-c", "exit 0" }, alloc);
-//     try child.spawn();
-//
-//     var xp = try xev.Process.init(child.id);
-//     defer xp.deinit();
-//
-//     const p = aio.Process.init(env.loop, xp);
-//     const rc = try p.wait();
-//     try std.testing.expectEqual(rc, 0);
-// }
-//
-// fn udpServer(info: *ServerInfo) !void {
-//     var address = try std.net.Address.parseIp4("127.0.0.1", 0);
-//     const xserver = try xev.UDP.init(address);
-//
-//     try xserver.bind(address);
-//
-//     var sock_len = address.getOsSockLen();
-//     try std.os.getsockname(xserver.fd, &address.any, &sock_len);
-//     info.addr = address;
-//
-//     const server = aio.UDP.init(env.loop, xserver);
-//
-//     var recv_buf: [128]u8 = undefined;
-//     const recv_len = try server.read(.{ .slice = &recv_buf });
-//     var send_buf = [_]u8{ 1, 1, 2, 3, 5, 8, 13 };
-//     try std.testing.expectEqual(recv_len, send_buf.len);
-//     try std.testing.expect(std.mem.eql(u8, &send_buf, recv_buf[0..recv_len]));
-//     try server.close();
-// }
-//
-// fn udpClient(info: *ServerInfo) !void {
-//     const xclient = try xev.UDP.init(info.addr);
-//     const client = aio.UDP.init(env.loop, xclient);
-//     var send_buf = [_]u8{ 1, 1, 2, 3, 5, 8, 13 };
-//     const send_len = try client.write(info.addr, .{ .slice = &send_buf });
-//     try std.testing.expectEqual(send_len, 7);
-//     try client.close();
-// }
-//
-// const NotifierState = struct {
-//     x: xev.Async,
-//     notified: bool = false,
-// };
-//
-// fn asyncTest(state: *NotifierState) !void {
-//     const notif = aio.Async.init(env.loop, state.x);
-//     try notif.wait();
-//     state.notified = true;
-// }
-//
-// fn asyncNotifier(state: *NotifierState) !void {
-//     try state.x.notify();
-//     try aio.sleep(env.loop, 100);
-//     try std.testing.expect(state.notified);
-// }
+test "aio timers" {
+    const t = try AioTest.init();
+    defer t.deinit();
+    try t.run(aioTimersMain);
+}
+
+fn tcpMain() !void {
+    const stack_size = 1024 * 32;
+
+    var info: ServerInfo = .{};
+
+    var fn1 = libcoro.CoroFunc(tcpServer, .{}).init();
+    const stack1 = try libcoro.stackAlloc(env.allocator, stack_size);
+    defer env.allocator.free(stack1);
+    var server_co = try fn1.coro(.{&info}, stack1);
+
+    var fn2 = libcoro.CoroFunc(tcpClient, .{}).init();
+    const stack2 = try libcoro.stackAlloc(env.allocator, stack_size);
+    defer env.allocator.free(stack2);
+    var client_co = try fn2.coro(.{&info}, stack2);
+
+    aio.xawait(.{ server_co, client_co });
+}
+
+test "aio tcp" {
+    const t = try AioTest.init();
+    defer t.deinit();
+    try t.run(tcpMain);
+}
+
+fn fileRW() !void {
+    const path = "test_watcher_file";
+    const f = try std.fs.cwd().createFile(path, .{
+        .read = true,
+        .truncate = true,
+    });
+    defer f.close();
+    defer std.fs.cwd().deleteFile(path) catch {};
+    const xfile = try xev.File.init(f);
+    const file = aio.File.init(env.loop, xfile);
+    var write_buf = [_]u8{ 1, 1, 2, 3, 5, 8, 13 };
+    const write_len = try file.write(.{ .slice = &write_buf });
+    try std.testing.expectEqual(write_len, write_buf.len);
+    try f.sync();
+    const f2 = try std.fs.cwd().openFile(path, .{});
+    defer f2.close();
+    const xfile2 = try xev.File.init(f2);
+    const file2 = aio.File.init(env.loop, xfile2);
+    var read_buf: [128]u8 = undefined;
+    const read_len = try file2.read(.{ .slice = &read_buf });
+    try std.testing.expectEqual(write_len, read_len);
+    try std.testing.expect(std.mem.eql(u8, &write_buf, read_buf[0..read_len]));
+}
+
+test "aio file" {
+    const t = try AioTest.init();
+    defer t.deinit();
+    try t.run(fileRW);
+}
+
+fn udpMain() !void {
+    const stack_size = 1024 * 32;
+    var info: ServerInfo = .{};
+
+    var fn1 = libcoro.CoroFunc(udpServer, .{}).init();
+    const stack1 = try libcoro.stackAlloc(env.allocator, stack_size);
+    defer env.allocator.free(stack1);
+    var server_co = try fn1.coro(.{&info}, stack1);
+
+    var fn2 = libcoro.CoroFunc(udpClient, .{}).init();
+    const stack2 = try libcoro.stackAlloc(env.allocator, stack_size);
+    defer env.allocator.free(stack2);
+    var client_co = try fn2.coro(.{&info}, stack2);
+
+    aio.xawait(.{ server_co, client_co });
+}
+
+test "aio udp" {
+    const t = try AioTest.init();
+    defer t.deinit();
+    try t.run(udpMain);
+}
+
+fn processTest() !void {
+    const alloc = std.heap.c_allocator;
+    var child = std.ChildProcess.init(&.{ "sh", "-c", "exit 0" }, alloc);
+    try child.spawn();
+
+    var xp = try xev.Process.init(child.id);
+    defer xp.deinit();
+
+    const p = aio.Process.init(env.loop, xp);
+    const rc = try p.wait();
+    try std.testing.expectEqual(rc, 0);
+}
+
+test "aio process" {
+    const t = try AioTest.init();
+    defer t.deinit();
+    try t.run(processTest);
+}
+
+fn asyncMain() !void {
+    const stack_size = 1024 * 32;
+    var nstate = NotifierState{ .x = try xev.Async.init() };
+
+    var fn1 = libcoro.CoroFunc(asyncTest, .{}).init();
+    const stack = try libcoro.stackAlloc(env.allocator, stack_size);
+    defer env.allocator.free(stack);
+    var co = try fn1.coro(.{&nstate}, stack);
+
+    var fn2 = libcoro.CoroFunc(asyncNotifier, .{}).init();
+    const stack2 = try libcoro.stackAlloc(env.allocator, stack_size);
+    defer env.allocator.free(stack2);
+    var nco = try fn2.coro(.{&nstate}, stack2);
+
+    aio.xawait(.{ co, nco });
+}
+
+test "aio async" {
+    const t = try AioTest.init();
+    defer t.deinit();
+    try t.run(asyncMain);
+}
+
+const ServerInfo = struct {
+    addr: std.net.Address = undefined,
+};
+
+fn tcpServer(info: *ServerInfo) !void {
+    var address = try std.net.Address.parseIp4("127.0.0.1", 0);
+    const xserver = try xev.TCP.init(address);
+
+    try xserver.bind(address);
+    try xserver.listen(1);
+
+    var sock_len = address.getOsSockLen();
+    try std.os.getsockname(xserver.fd, &address.any, &sock_len);
+    info.addr = address;
+
+    const server = aio.TCP.init(env.loop, xserver);
+    const conn = try server.accept();
+    defer conn.close() catch unreachable;
+    try server.close();
+
+    var recv_buf: [128]u8 = undefined;
+    const recv_len = try conn.read(.{ .slice = &recv_buf });
+    const send_buf = [_]u8{ 1, 1, 2, 3, 5, 8, 13 };
+    try std.testing.expect(std.mem.eql(u8, &send_buf, recv_buf[0..recv_len]));
+}
+
+fn tcpClient(info: *ServerInfo) !void {
+    const address = info.addr;
+    const xclient = try xev.TCP.init(address);
+    const client = aio.TCP.init(env.loop, xclient);
+    defer client.close() catch unreachable;
+    _ = try client.connect(address);
+    var send_buf = [_]u8{ 1, 1, 2, 3, 5, 8, 13 };
+    const send_len = try client.write(.{ .slice = &send_buf });
+    try std.testing.expectEqual(send_len, 7);
+}
+
+fn udpServer(info: *ServerInfo) !void {
+    var address = try std.net.Address.parseIp4("127.0.0.1", 0);
+    const xserver = try xev.UDP.init(address);
+
+    try xserver.bind(address);
+
+    var sock_len = address.getOsSockLen();
+    try std.os.getsockname(xserver.fd, &address.any, &sock_len);
+    info.addr = address;
+
+    const server = aio.UDP.init(env.loop, xserver);
+
+    var recv_buf: [128]u8 = undefined;
+    const recv_len = try server.read(.{ .slice = &recv_buf });
+    var send_buf = [_]u8{ 1, 1, 2, 3, 5, 8, 13 };
+    try std.testing.expectEqual(recv_len, send_buf.len);
+    try std.testing.expect(std.mem.eql(u8, &send_buf, recv_buf[0..recv_len]));
+    try server.close();
+}
+
+fn udpClient(info: *ServerInfo) !void {
+    const xclient = try xev.UDP.init(info.addr);
+    const client = aio.UDP.init(env.loop, xclient);
+    var send_buf = [_]u8{ 1, 1, 2, 3, 5, 8, 13 };
+    const send_len = try client.write(info.addr, .{ .slice = &send_buf });
+    try std.testing.expectEqual(send_len, 7);
+    try client.close();
+}
+
+const NotifierState = struct {
+    x: xev.Async,
+    notified: bool = false,
+};
+
+fn asyncTest(state: *NotifierState) !void {
+    const notif = aio.Async.init(env.loop, state.x);
+    try notif.wait();
+    state.notified = true;
+}
+
+fn asyncNotifier(state: *NotifierState) !void {
+    try state.x.notify();
+    try aio.sleep(env.loop, 100);
+    try std.testing.expect(state.notified);
+}

--- a/src/test_aio.zig
+++ b/src/test_aio.zig
@@ -41,7 +41,7 @@ const AioTest = struct {
     }
 
     fn run(self: @This(), func: anytype) !void {
-        const stack = try libcoro.stackAlloc(self.allocator, 1024 * 8);
+        const stack = try libcoro.stackAlloc(self.allocator, 1024 * 32);
         defer self.allocator.free(stack);
         try aio.run(self.loop, func, .{}, stack);
     }


### PR DESCRIPTION
Add top-level run for coroutine kick-off.
Add asyncio.xawait for parallel execution.
Store everything but the return value in the coro stack. Clean up aio tests.