### PR TITLE
Fix suspension for completion ignored

### DIFF
--- a/src/asyncio.zig
+++ b/src/asyncio.zig
@@ -89,7 +89,7 @@ fn waitForCompletion(exec: ?*Executor, c: *xev.Completion) !void {
     const exec_ = getExec(exec);
     if (libcoro.inCoro()) {
         // In a coroutine; wait for it to be resumed
-        libcoro.xsuspend();
+        while (c.state() != .dead) libcoro.xsuspend();
     } else {
         // Not in a coroutine, blocking call
         while (c.state() != .dead) try exec_.tick();


### PR DESCRIPTION
**Reproduction example**

```zig
const std = @import("std");
const libcoro = @import("libcoro");
const xev = @import("xev");
const aio = libcoro.asyncio;

fn asyncMain(executor: *aio.Executor) !void {
    var notification = aio.AsyncNotification.init(executor, try xev.Async.init());
    defer notification.notif.deinit();

    const frame = try aio.xasync(struct {
        fn call(executor_: *aio.Executor) !void {
            try aio.sleep(executor_, 1);
        }
    }.call, .{executor}, null);
    defer frame.deinit();

    try notification.wait();
    try libcoro.xawait(frame);
    unreachable;
}

pub fn main() anyerror!void {
    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
    defer _ = gpa.deinit();
    const allocator = gpa.allocator();

    var thread_pool = xev.ThreadPool.init(.{});
    defer {
        thread_pool.shutdown();
        thread_pool.deinit();
    }

    var loop = try xev.Loop.init(.{
        .thread_pool = &thread_pool,
    });
    defer loop.deinit();

    var executor = aio.Executor.init(&loop);

    aio.initEnv(.{
        .stack_allocator = allocator,
        .default_stack_size = 16 * 1024 * 1024,
    });

    try aio.run(&executor, asyncMain, .{&executor}, null);
}
```

**Expected behavior**

Execution is blocked on `notification.wait()`. 

**Actual behavior**

After `frame` coroutine awaited and done we go back the async main coroutine, set as done and go back on the root coroutine while we should  be back on the root coroutine without setting as done the async main one.

<details>
<summary>Logs</summary>
Erroring behavior 

```log
coro resume CoroId{.cid=1, .i=-1} from CoroId{.cid=0, .i=-1}
coro start CoroId{.cid=1, .i=0}
coro resume CoroId{.cid=2, .i=-1} from CoroId{.cid=1, .i=0}
coro start CoroId{.cid=2, .i=0}
coro suspend CoroId{.cid=2, .i=0} to CoroId{.cid=1, .i=0}
coro suspend CoroId{.cid=1, .i=1} to CoroId{.cid=0, .i=-1}
coro resume CoroId{.cid=2, .i=0} from CoroId{.cid=0, .i=0}
coro done CoroId{.cid=2, .i=1}
coro suspend CoroId{.cid=2, .i=1} to CoroId{.cid=1, .i=1}
coro done CoroId{.cid=1, .i=2}
coro suspend CoroId{.cid=1, .i=2} to CoroId{.cid=0, .i=0}
Executor.tick readyq_len=0
Executor.tick done
```

Expected behavior 

```log
coro resume CoroId{.cid=1, .i=-1} from CoroId{.cid=0, .i=-1}
coro start CoroId{.cid=1, .i=0}
coro resume CoroId{.cid=2, .i=-1} from CoroId{.cid=1, .i=0}
coro start CoroId{.cid=2, .i=0}
coro suspend CoroId{.cid=2, .i=0} to CoroId{.cid=1, .i=0}
coro suspend CoroId{.cid=1, .i=1} to CoroId{.cid=0, .i=-1}
coro resume CoroId{.cid=2, .i=0} from CoroId{.cid=0, .i=0}
coro done CoroId{.cid=2, .i=1}
coro suspend CoroId{.cid=2, .i=1} to CoroId{.cid=1, .i=1}
coro suspend CoroId{.cid=1, .i=2} to CoroId{.cid=0, .i=0}
Executor.tick readyq_len=0
Executor.tick done
```

</details>

**Proposed solution**

Suspend the coroutine until the xev completion is gone from the loop to ensure that we switch to the right coroutine.

**Note**

Added an integration test a little bit complex that represent a full use case of zigcoro.
