### PR TITLE
Made CoroT.init and getStack pub

### DIFF
--- a/src/coro.zig
+++ b/src/coro.zig
@@ -48,7 +48,7 @@ const StackInfo = struct {
     stack: StackT,
     owned: bool,
 };
-fn getStack(stack: anytype) !StackInfo {
+pub fn getStack(stack: anytype) !StackInfo {
     const T = @TypeOf(stack);
     const is_optional = @typeInfo(T) == .optional;
     if (T == @TypeOf(null) or (is_optional and stack == null)) {

--- a/src/coro.zig
+++ b/src/coro.zig
@@ -315,7 +315,7 @@ const CoroT = struct {
             /// Create a Coro
             /// self and stack pointers must remain stable for the lifetime of
             /// the coroutine.
-            fn init(
+            pub fn init(
                 args: Sig.ArgsT,
                 stack: StackT,
                 owns_stack: bool,


### PR DESCRIPTION
Closes #35

getStack is also now pub, so it's possible to allocate a stack with Env for CoroT.init